### PR TITLE
improve robustness on text file busy error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ahall/app-reloader
+
+go 1.15


### PR DESCRIPTION
- Add go.mod
- Address error when sometimes fails to execute a new binary with "text file busy error"  